### PR TITLE
Make the `type: blocks` field work with `{{ block() }}`.

### DIFF
--- a/base-2016/page.twig
+++ b/base-2016/page.twig
@@ -15,7 +15,7 @@
     {{ record.body }}
 
     {# If there are repeaters, we should output them. #}
-    {% with { 'record': record, 'common': false, 'repeaters': true, 'exclude': ['teaser', 'body', 'image'] } %}
+    {% with { 'record': record, 'common': false, 'repeaters': true, 'blocks': true, 'exclude': ['teaser', 'body', 'image'] } %}
     {{ block('sub_fields', 'partials/_sub_fields.twig') }}
     {% endwith %}
 

--- a/base-2016/partials/_sub_fields.twig
+++ b/base-2016/partials/_sub_fields.twig
@@ -8,7 +8,7 @@
       ContentType definitions as well as passed in variables.
     - The last section is where the actual looping is done, and the relevant
       {{ block() }} function is called, for the 'ContentType fields',
-      'repeater fields' and 'template fields' in turn.
+      'repeater fields', 'block fields' and 'template fields' in turn.
 
    Read the relevant section in the documentation on usage of this
    functionality: https://docs.bolt.cm/templating
@@ -63,8 +63,9 @@
 
         {% endif %}
 
-        {# Finally, the repeaters #}
-        {% if repeaters|default(false) == true and record.fieldtype(key) == "repeater" %}
+        {# Finally, the repeaters and blocks #}
+        {% if (repeaters|default(false) == true and record.fieldtype(key) == "repeater") or
+              (blocks|default(false) == true and record.fieldtype(key) == "block") %}
 
             {% if (global.request.get('_route') != "preview") %}
 
@@ -86,7 +87,7 @@
                 fixed properly for Bolt 4, but for now we just output a notice, and prevent crashes.
                 See also: https://github.com/bolt/bolt/issues/6605 #}
                 <p>
-                Unfortunately, Repeater fields do not work correctly with the generic
+                Unfortunately, Repeater and Block fields do not work correctly with the generic
                 <code>block()</code> function, when using Preview. To view these fields, please
                 save the record, and view the page normally.
                 </p>

--- a/base-2016/record.twig
+++ b/base-2016/record.twig
@@ -7,7 +7,7 @@
     {# Output all fields, in the order as defined in the contenttype.
        To change the generated html and configure the options, see:
        https://docs.bolt.cm/templating #}
-    {% with { 'record': record, 'extended': true, 'repeaters': true } %}
+    {% with { 'record': record, 'extended': true, 'repeaters': true, 'blocks': true } %}
         {{ block('sub_fields', 'partials/_sub_fields.twig') }}
     {% endwith %}
 

--- a/skeleton/partials/_sub_fields.twig
+++ b/skeleton/partials/_sub_fields.twig
@@ -8,7 +8,7 @@
       ContentType definitions as well as passed in variables.
     - The last section is where the actual looping is done, and the relevant
       {{ block() }} function is called, for the 'ContentType fields',
-      'repeater fields' and 'template fields' in turn.
+      'repeater fields', 'block fields' and 'template fields' in turn.
 
    Read the relevant section in the documentation on usage of this
    functionality: https://docs.bolt.cm/templating
@@ -63,8 +63,9 @@
 
         {% endif %}
 
-        {# Finally, the repeaters #}
-        {% if repeaters|default(false) == true and record.fieldtype(key) == "repeater" %}
+        {# Finally, the repeaters and blocks #}
+        {% if (repeaters|default(false) == true and record.fieldtype(key) == "repeater") or
+              (blocks|default(false) == true and record.fieldtype(key) == "block") %}
 
             {% if (global.request.get('_route') != "preview") %}
 
@@ -86,7 +87,7 @@
                 fixed properly for Bolt 4, but for now we just output a notice, and prevent crashes.
                 See also: https://github.com/bolt/bolt/issues/6605 #}
                 <p>
-                Unfortunately, Repeater fields do not work correctly with the generic
+                Unfortunately, Repeater and Block fields do not work correctly with the generic
                 <code>block()</code> function, when using Preview. To view these fields, please
                 save the record, and view the page normally.
                 </p>

--- a/skeleton/record.twig
+++ b/skeleton/record.twig
@@ -7,7 +7,7 @@
     {# Output all fields, in the order as defined in the contenttype.
        To change the generated html and configure the options, see:
        https://docs.bolt.cm/templating #}
-    {% with { 'record': record, 'common': true, 'extended': true, 'repeaters': true } %}
+    {% with { 'record': record, 'common': true, 'extended': true, 'repeaters': true, 'blocks': true } %}
         {{ block('sub_fields', 'partials/_sub_fields.twig') }}
     {% endwith %}
 


### PR DESCRIPTION
Fixes https://github.com/bolt/bolt/issues/7138