### PR TITLE
Wrongly nested closing 'div' element

### DIFF
--- a/base-2018/page.twig
+++ b/base-2018/page.twig
@@ -36,8 +36,8 @@
                     #}
 
                     {{ include('partials/_recordfooter.twig', { 'record': record, 'extended': true }) }}
-                </div>
-            </article>
+                </article>
+            </div>
             <div class="column">
                 {{ include('partials/_aside.twig') }}
             </div>

--- a/base-2018/record.twig
+++ b/base-2018/record.twig
@@ -32,8 +32,8 @@
                     #}
 
                     {{ include('partials/_recordfooter.twig', { 'record': record, 'extended': true }) }}
-                </div>
-            </article>
+                </article>
+            </div>
         </div>
     </div>
 </section>


### PR DESCRIPTION
The closing 'div' element is wrongly nested. Corrected to be **after** the closing 'article' element.