### PR TITLE
Description of fields with labels from contenttype

### DIFF
--- a/base-2018/partials/_sub_field_blocks.twig
+++ b/base-2018/partials/_sub_field_blocks.twig
@@ -64,14 +64,14 @@
 
     {# Special case for 'select' fields: if it's a multiple select, the value is an array. #}
     {% if fieldtype == "select" and value is not empty %}
-        <p><strong>{{ key }}: </strong>
+        <p><strong>{% if record.contenttype.fields[key].label is empty %}{{ key }}{% else %}{{ record.contenttype.fields[key].label }}{% endif %}: </strong>
         {{ value|join(", ") }}
         </p>
     {% endif %}
 
     {# Checkbox fields #}
     {% if fieldtype == "checkbox" %}
-        <p><strong>Checkbox {{ key }}: </strong>
+        <p><strong>Checkbox {% if record.contenttype.fields[key].label is empty %}{{ key }}{% else %}{{ record.contenttype.fields[key].label }}{% endif %}: </strong>
         {{ value ? "checked" : "not checked" }}</p>
     {% endif %}
 
@@ -83,7 +83,7 @@
     {# No special case defined for this type of field. We just output them, if it's
        a simple scalar, and 'dump' them otherwise. #}
     {% if fieldtype in [ 'filelist', 'datetime', 'date', 'integer', 'float' ] and value is not empty  %}
-        <p><strong>{{ key }}: </strong>
+        <p><strong>{% if record.contenttype.fields[key].label is empty %}{{ key }}{% else %}{{ record.contenttype.fields[key].label }}{% endif %}: </strong>
         {% if value is iterable %}
             {{ dump(value) }}
         {% else %}


### PR DESCRIPTION
The documentation says labels of fields defined in contenttypes.yml are for the built-in editing form.
But there is no hint if it's for labeling the fields for the webpage, too. 
With this commit, you take the label from the contenttype if it's not empty else you take the key.