### PR TITLE
fix(base-2018): fix block image alt title

### DIFF
--- a/base-2018/partials/_aside.twig
+++ b/base-2018/partials/_aside.twig
@@ -17,7 +17,7 @@
             output a default text, telling the user to create the 'blocks' in the backend. #}
         {% if block %}
 
-            <img src="{{ block|thumbnail(480, 320) }}" alt="block|image.alt">
+            <img src="{{ block|thumbnail(480, 320) }}" alt="{{ block|image.alt }}">
 
             <h2 class="title">{{ block|title }}</h2>
             <p>{{ block.content|default(block|excerpt) }}</p>


### PR DESCRIPTION
Image Alt title not shown because of missing twig syntax. 
![image](https://user-images.githubusercontent.com/19831569/233357310-b6cb59ba-0b8d-420a-a773-d88b09b451d1.png)
